### PR TITLE
Adding system-ui to the fontstack

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 }
 
 body {
-  font-family: sans-serif;
+  font-family: system-ui, sans-serif;
   display: flex;
   height: 100%;
   line-height: 1;


### PR DESCRIPTION
I like using the `system-ui` font as a default (which displays "San Francisco” in Safari on recent macOS and iOS releases), so I simply added this statement. Not every browser will currently render the system font (e.g. Firefox on macOS won’t), but I don’t see a need for a more complicated font stack.
Also, this is probably a matter of personal taste, too.

Again, if you don’t want this, simply close the PR.