### PR TITLE
Highlight new day on visibility change

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,21 +142,29 @@ function hightlightCurrentDay() {
   var today = new Date();
 
   days.forEach((day, index) => {
-    //remove existing date-span(s) first, so on re-runs new spans do not get appended all the time
-    var existingSpan = day.querySelector(".heading > span");
-    if (existingSpan != null) { existingSpan.remove() }
-
+    unhighlightDay(day);
     if (index === today.getDay() - 1) {
-      day.setAttribute("aria-current", "date");
-
-      let span = document.createElement("span");
-      span.innerHTML = today.getDate() + "." + (today.getMonth() + 1) + ".";
-
-      day.querySelector("textarea").setAttribute("autofocus", true);
-      day.querySelector(".heading").append(span);
+      highlightDay(day, today.getDate() + "." + (today.getMonth() + 1) + ".");
     }
-
   });
+}
+
+function highlightDay(day, dateString) {
+  day.setAttribute("aria-current", "date");
+
+  let span = document.createElement("span");
+  span.innerHTML = dateString;
+
+  day.querySelector("textarea").setAttribute("autofocus", true);
+  day.querySelector("textarea").focus();
+  day.querySelector(".heading").append(span);
+}
+
+function unhighlightDay(day) {
+  day.removeAttribute("aria-current");
+  day.querySelector("textarea").removeAttribute("autofocus");
+  let existingSpan = day.querySelector(".heading > span");
+  if (existingSpan != null) { existingSpan.remove() }
 }
 
 hightlightCurrentDay();

--- a/index.html
+++ b/index.html
@@ -129,7 +129,6 @@ textarea:focus {
 <script>
 const days  = Array.from(document.querySelectorAll(".day"));
 const notes = Array.from(document.querySelectorAll("textarea"));
-const today = new Date();
 
 document.addEventListener("keydown", e => {
   if (e.metaKey === true && e.key === "s") {
@@ -139,6 +138,8 @@ document.addEventListener("keydown", e => {
 
 function hightlightCurrentDay() {
   if (document.visibilityState != 'visible') { return; }
+
+  var today = new Date();
 
   days.forEach((day, index) => {
     //remove existing date-span(s) first, so on re-runs new spans do not get appended all the time

--- a/index.html
+++ b/index.html
@@ -137,20 +137,29 @@ document.addEventListener("keydown", e => {
   }
 });
 
-// add current date
-days.forEach((day, index) => {
+function hightlightCurrentDay() {
+  if (document.visibilityState != 'visible') { return; }
 
-  if (index === today.getDay() - 1) {
-    day.setAttribute("aria-current", "date");
+  days.forEach((day, index) => {
+    //remove existing date-span(s) first, so on re-runs new spans do not get appended all the time
+    var existingSpan = day.querySelector(".heading > span");
+    if (existingSpan != null) { existingSpan.remove() }
 
-    let span = document.createElement("span");
-    span.innerHTML = today.getDate() + "." + (today.getMonth() + 1) + ".";
+    if (index === today.getDay() - 1) {
+      day.setAttribute("aria-current", "date");
 
-    day.querySelector("textarea").setAttribute("autofocus", true);
-    day.querySelector(".heading").append(span);
-  }
+      let span = document.createElement("span");
+      span.innerHTML = today.getDate() + "." + (today.getMonth() + 1) + ".";
 
-});
+      day.querySelector("textarea").setAttribute("autofocus", true);
+      day.querySelector(".heading").append(span);
+    }
+
+  });
+}
+
+hightlightCurrentDay();
+document.addEventListener('visibilitychange', hightlightCurrentDay);
 
 // handle note-taking
 notes.forEach(note => {


### PR DESCRIPTION
This will re-highlight the current day again via the `visibilitychange` event, whenever the window becomes visible again. This way, you do not have to refresh the page on a new day, to get the highlighting.

Admittedly, a simple page-refresh does the same. But I thought it’d be nice not having to do this and avoid the possible UI confusion when you come back on a new day.

Of course, this probably only makes sense if you – like me – have this always open in like a pinned tab and do not open this anew on the next day.

Also, this could be more efficient by running the actual highlighting code only when necessary. But this works and I got lazy... 😉