### PR TITLE
Better shrinking of textareas

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,9 @@
 }
 
 :root {
+  color-scheme: light dark;
   --color-background: #fff;
-  --color-day-background:  rgba(0,0,0, .075);
+  --color-day-background: rgba(0,0,0, .075);
   --color-day-border: var(--color-background);
   --color-day-text: #000;
   --color-focus: rgba(34, 144, 255, .5);
@@ -20,6 +21,18 @@
   --color-today-text: #000;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: #222;
+    --color-day-background: rgba(255,255,255, .075);
+    --color-day-border: var(--color-background);
+    --color-day-text: #ddd;
+    --color-focus: rgba(34, 144, 255, .5);
+    --color-today-background: rgba(253, 226, 144, .5);
+    --color-today-border: rgba(255,255,255, .5);
+    --color-today-text: #fff;
+  }
+}
 body {
   font-family: sans-serif;
   display: flex;
@@ -84,6 +97,7 @@ textarea {
   font: inherit;
   padding: .5rem;
   line-height: 1.5em;
+  color: var(--color-day-text);
 }
 
 textarea:focus {

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ body {
 .plan {
   padding: 1rem;
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(6, minmax(120px, 1fr));
   grid-template-rows: 66% auto;
   grid-gap: .5rem;
   flex-basis: 100%;
@@ -61,6 +61,11 @@ body {
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: .05em;
+}
+
+.heading span {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .notes {

--- a/index.html
+++ b/index.html
@@ -142,21 +142,29 @@ function hightlightCurrentDay() {
   var today = new Date();
 
   days.forEach((day, index) => {
-    //remove existing date-span(s) first, so on re-runs new spans do not get appended all the time
-    var existingSpan = day.querySelector(".heading > span");
-    if (existingSpan != null) { existingSpan.remove() }
-
+    unhighlightDay(day);
     if (index === today.getDay() - 1) {
-      day.setAttribute("aria-current", "date");
-
-      let span = document.createElement("span");
-      span.innerHTML = today.getDate() + "." + (today.getMonth() + 1) + ".";
-
-      day.querySelector("textarea").setAttribute("autofocus", true);
-      day.querySelector(".heading").append(span);
+      highlightDay(day, today.getDate() + "." + (today.getMonth() + 1) + ".");
     }
-
   });
+}
+
+function highlightDay(day, dateString) {
+  day.setAttribute("aria-current", "date");
+
+  let span = document.createElement("span");
+  span.innerHTML = dateString;
+
+  day.querySelector("textarea").setAttribute("autofocus", true);
+  day.querySelector("textarea").focus();
+  day.querySelector(".heading").append(span);
+}
+
+function unhighlightDay(day) {
+  day.removeAttribute("aria-current");
+  day.querySelector("textarea").removeAttribute("autofocus");
+  let existingSpan = day.querySelector(".heading > span");
+  if (existingSpan != null) { existingSpan.remove() }
 }
 
 hightlightCurrentDay();

--- a/index.html
+++ b/index.html
@@ -129,7 +129,6 @@ textarea:focus {
 <script>
 const days  = Array.from(document.querySelectorAll(".day"));
 const notes = Array.from(document.querySelectorAll("textarea"));
-const today = new Date();
 
 document.addEventListener("keydown", e => {
   if (e.metaKey === true && e.key === "s") {
@@ -139,6 +138,8 @@ document.addEventListener("keydown", e => {
 
 function hightlightCurrentDay() {
   if (document.visibilityState != 'visible') { return; }
+
+  var today = new Date();
 
   days.forEach((day, index) => {
     //remove existing date-span(s) first, so on re-runs new spans do not get appended all the time

--- a/index.html
+++ b/index.html
@@ -137,20 +137,29 @@ document.addEventListener("keydown", e => {
   }
 });
 
-// add current date
-days.forEach((day, index) => {
+function hightlightCurrentDay() {
+  if (document.visibilityState != 'visible') { return; }
 
-  if (index === today.getDay() - 1) {
-    day.setAttribute("aria-current", "date");
+  days.forEach((day, index) => {
+    //remove existing date-span(s) first, so on re-runs new spans do not get appended all the time
+    var existingSpan = day.querySelector(".heading > span");
+    if (existingSpan != null) { existingSpan.remove() }
 
-    let span = document.createElement("span");
-    span.innerHTML = today.getDate() + "." + (today.getMonth() + 1) + ".";
+    if (index === today.getDay() - 1) {
+      day.setAttribute("aria-current", "date");
 
-    day.querySelector("textarea").setAttribute("autofocus", true);
-    day.querySelector(".heading").append(span);
-  }
+      let span = document.createElement("span");
+      span.innerHTML = today.getDate() + "." + (today.getMonth() + 1) + ".";
 
-});
+      day.querySelector("textarea").setAttribute("autofocus", true);
+      day.querySelector(".heading").append(span);
+    }
+
+  });
+}
+
+hightlightCurrentDay();
+document.addEventListener('visibilitychange', hightlightCurrentDay);
 
 // handle note-taking
 notes.forEach(note => {

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 }
 
 body {
-  font-family: sans-serif;
+  font-family: system-ui, sans-serif;
   display: flex;
   height: 100%;
   line-height: 1;


### PR DESCRIPTION
Thanks for merging all my previous PRs, Bastian.

Here’s another suggestion.
I noticed that on smaller screens, I could allow the day textareas to shrink some more than the default. That way, the UI will fit better on smaller browser windows.

If you want to try this out, simply open this branch in a window, resize it down and compare to the current master branch version.

(I’m not a CSS Grid expert, so I don’t know what determines the _default_ minimum each element in the grid should take up. But for me, this seemed unnecessarily wide. And 120px seemed like a better fit to me.)